### PR TITLE
disable calico on GCP since it's legacy and causes lots of trouble

### DIFF
--- a/terraform/aptos-node/gcp/cluster.tf
+++ b/terraform/aptos-node/gcp/cluster.tf
@@ -53,8 +53,7 @@ resource "google_container_cluster" "aptos" {
   }
 
   network_policy {
-    enabled  = true
-    provider = "CALICO"
+    enabled  = false
   }
 
   cluster_autoscaling {

--- a/terraform/fullnode/gcp/cluster.tf
+++ b/terraform/fullnode/gcp/cluster.tf
@@ -57,8 +57,7 @@ resource "google_container_cluster" "aptos" {
   }
 
   network_policy {
-    enabled  = true
-    provider = "CALICO"
+    enabled  = false
   }
 
   cluster_autoscaling {


### PR DESCRIPTION
Disable Calico network policy since it's kinda legacy on GKE and causes trouble with downscaling cluster nodes.